### PR TITLE
Add OCR PDF parsing and ledger export

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,10 +4,11 @@ This project is a small prototype of a bookkeeping application built with [Strea
 
 ## Features
 
-- Upload bank statements in CSV format
+- Upload bank statements in CSV **or PDF** format (basic OCR support)
 - Parse invoice PDFs and match them to transactions
+- Classify transactions into GL accounts using a lightweight classifier
 - Generate a simple general ledger and trial balance
-- Download the trial balance as CSV
+- Download the trial balance and general ledger as CSV, with optional PDF/Excel export if dependencies are installed
 
 ## Installation
 
@@ -15,8 +16,8 @@ This project is a small prototype of a bookkeeping application built with [Strea
 2. Install the project dependencies:
    ```bash
    pip install -r requirements.txt
-   # Optional: install PyPDF2 for better invoice parsing
-   pip install PyPDF2
+   # Optional: install extra libraries for better PDF parsing and exports
+   pip install PyPDF2 pdf2image pytesseract pandas fpdf
    ```
    The `requirements.txt` file includes `pytest` so you can run the test suite.
 

--- a/components/dashboard.py
+++ b/components/dashboard.py
@@ -1,10 +1,13 @@
 import csv
 import io
+import os
+import tempfile
 import streamlit as st
 from components.invoice_matcher_ui import run_invoice_matcher
 from utils.ledger import generate_ledger
 from utils.trial_balance import generate_trial_balance
-from utils.export import export_trial_balance
+from utils.export import export_trial_balance, export_general_ledger
+from utils.pdf_utils import parse_bank_statement_pdf
 
 def launch_dashboard(session):
     """Main dashboard screen shown after login."""
@@ -13,13 +16,20 @@ def launch_dashboard(session):
     st.success(f"Welcome {session['user']['email']}")
 
     st.subheader("Upload Bank Statement")
-    bank_file = st.file_uploader("Bank Statement (.csv)", type=["csv"])
+    bank_file = st.file_uploader("Bank Statement (.csv or .pdf)", type=["csv", "pdf"])
     bank_rows = []
     if bank_file:
         try:
-            content = bank_file.getvalue().decode("utf-8", errors="ignore")
-            reader = csv.DictReader(io.StringIO(content))
-            bank_rows = list(reader)
+            if bank_file.type == "application/pdf" or bank_file.name.lower().endswith(".pdf"):
+                with tempfile.NamedTemporaryFile(delete=False, suffix=".pdf") as tmp:
+                    tmp.write(bank_file.read())
+                    tmp_path = tmp.name
+                bank_rows = parse_bank_statement_pdf(tmp_path)
+                os.unlink(tmp_path)
+            else:
+                content = bank_file.getvalue().decode("utf-8", errors="ignore")
+                reader = csv.DictReader(io.StringIO(content))
+                bank_rows = list(reader)
             st.write("Transactions")
             st.table(bank_rows)
         except Exception as exc:
@@ -36,4 +46,5 @@ def launch_dashboard(session):
         st.subheader("Trial Balance")
         st.table(tb)
 
+        export_general_ledger(gl)
         export_trial_balance(tb)

--- a/utils/classifier.py
+++ b/utils/classifier.py
@@ -1,0 +1,12 @@
+"""Simple transaction classifier used as a stand-in for an AI model."""
+
+
+def classify_transaction(description):
+    desc = str(description).lower()
+    if "mtn" in desc or "tel" in desc:
+        return "6100/000 - Telecoms Expense"
+    if "salary" in desc or "payroll" in desc:
+        return "5000/000 - Payroll"
+    if "invoice" in desc or "sale" in desc or "customer" in desc:
+        return "4000/000 - Sales"
+    return "1000/000 - Cash"

--- a/utils/export.py
+++ b/utils/export.py
@@ -5,6 +5,37 @@ import io
 import streamlit as st
 
 
+def _to_excel(rows):
+    """Return an XLSX bytes object for the rows if pandas is available."""
+    try:
+        import pandas as pd  # pragma: no cover - optional dependency
+
+        df = pd.DataFrame(rows)
+        output = io.BytesIO()
+        df.to_excel(output, index=False)
+        return output.getvalue()
+    except Exception:  # pragma: no cover - optional dependency
+        return None
+
+
+def _to_pdf(rows, title):
+    """Return a PDF bytes object for the rows if FPDF is available."""
+    try:
+        from fpdf import FPDF  # pragma: no cover - optional dependency
+
+        pdf = FPDF()
+        pdf.add_page()
+        pdf.set_font("Arial", size=12)
+        pdf.cell(200, 10, txt=title, ln=1)
+        headers = list(rows[0].keys()) if rows else []
+        for row in rows:
+            line = " | ".join(str(row.get(h, "")) for h in headers)
+            pdf.cell(200, 10, txt=line, ln=1)
+        return pdf.output(dest="S").encode("latin1")
+    except Exception:  # pragma: no cover - optional dependency
+        return None
+
+
 def _to_csv(rows):
     """Return a CSV string for the provided row dictionaries."""
 
@@ -27,3 +58,47 @@ def export_trial_balance(tb):
     st.download_button(
         "Download Trial Balance (CSV)", data=csv_data, file_name="trial_balance.csv"
     )
+
+    pdf_data = _to_pdf(tb, "Trial Balance")
+    if pdf_data:
+        st.download_button(
+            "Download Trial Balance (PDF)",
+            data=pdf_data,
+            file_name="trial_balance.pdf",
+        )
+
+    excel_data = _to_excel(tb)
+    if excel_data:
+        st.download_button(
+            "Download Trial Balance (Excel)",
+            data=excel_data,
+            file_name="trial_balance.xlsx",
+        )
+
+
+def export_general_ledger(gl_rows):
+    """Expose download buttons for the general ledger."""
+
+    if not gl_rows:
+        return
+
+    csv_data = _to_csv(gl_rows)
+    st.download_button(
+        "Download General Ledger (CSV)", data=csv_data, file_name="general_ledger.csv"
+    )
+
+    pdf_data = _to_pdf(gl_rows, "General Ledger")
+    if pdf_data:
+        st.download_button(
+            "Download General Ledger (PDF)",
+            data=pdf_data,
+            file_name="general_ledger.pdf",
+        )
+
+    excel_data = _to_excel(gl_rows)
+    if excel_data:
+        st.download_button(
+            "Download General Ledger (Excel)",
+            data=excel_data,
+            file_name="general_ledger.xlsx",
+        )

--- a/utils/invoice_matcher.py
+++ b/utils/invoice_matcher.py
@@ -8,11 +8,7 @@ text and the fuzzy matching uses :mod:`difflib`.
 import re
 from difflib import SequenceMatcher
 
-try:  # optional dependency for better PDF parsing
-    from PyPDF2 import PdfReader
-    _HAS_PYPDF = True
-except Exception:  # pragma: no cover - optional dependency
-    _HAS_PYPDF = False
+from .pdf_utils import extract_text
 
 def extract_invoice_data_from_pdf(pdf_file_path):
     """Parse a PDF invoice and return basic invoice data.
@@ -30,16 +26,7 @@ def extract_invoice_data_from_pdf(pdf_file_path):
     """
 
     try:
-        if _HAS_PYPDF:
-            reader = PdfReader(pdf_file_path)
-            text = "\n".join(page.extract_text() or "" for page in reader.pages)
-        else:
-            with open(pdf_file_path, "rb") as fh:
-                data = fh.read()
-            try:
-                text = data.decode("utf-8")
-            except UnicodeDecodeError:
-                text = data.decode("latin1", errors="ignore")
+        text = extract_text(pdf_file_path, ocr=True)
     except Exception as exc:  # pragma: no cover - I/O failures
         raise ValueError(f"Failed to read PDF '{pdf_file_path}': {exc}") from exc
 

--- a/utils/ledger.py
+++ b/utils/ledger.py
@@ -1,5 +1,12 @@
+from .classifier import classify_transaction
+
+
 def generate_ledger(bank_rows):
-    """Create a rudimentary general ledger from a bank statement."""
+    """Create a rudimentary general ledger from a bank statement.
+
+    The GL account for each transaction is determined using a simple
+    classifier which acts as a lightweight stand-in for an AI model.
+    """
 
     if not bank_rows:
         return bank_rows
@@ -7,9 +14,7 @@ def generate_ledger(bank_rows):
     ledger = []
     for row in bank_rows:
         entry = row.copy()
-        entry["GL Account"] = (
-            "6100/000 - Expense" if "MTN" in str(row.get("Description", "")).upper() else "1000/000 - Cash"
-        )
+        entry["GL Account"] = classify_transaction(row.get("Description", ""))
         try:
             amount = float(str(row.get("Amount", 0)).replace(",", ""))
         except ValueError:

--- a/utils/pdf_utils.py
+++ b/utils/pdf_utils.py
@@ -1,0 +1,54 @@
+import io
+import csv
+import re
+
+
+def extract_text(pdf_file_path, ocr=False):
+    """Return text from a PDF file. If ``ocr`` is True and pytesseract is
+    available, it will attempt OCR after converting pages to images.
+    """
+    text = ""
+    if ocr:
+        try:
+            from pdf2image import convert_from_path  # pragma: no cover - optional
+            import pytesseract  # pragma: no cover - optional
+
+            images = convert_from_path(pdf_file_path)
+            text = "\n".join(pytesseract.image_to_string(img) for img in images)
+        except Exception:
+            text = ""
+
+    if not text.strip():
+        try:
+            from PyPDF2 import PdfReader  # pragma: no cover - optional
+
+            reader = PdfReader(pdf_file_path)
+            text = "\n".join(page.extract_text() or "" for page in reader.pages)
+        except Exception:
+            try:
+                with open(pdf_file_path, "rb") as fh:
+                    data = fh.read()
+                text = data.decode("utf-8")
+            except Exception:
+                with open(pdf_file_path, "rb") as fh:
+                    data = fh.read()
+                text = data.decode("latin1", errors="ignore")
+    return text
+
+
+def parse_bank_statement_pdf(pdf_file_path):
+    """Parse a bank statement PDF and return a list of row dictionaries."""
+    text = extract_text(pdf_file_path, ocr=True)
+    rows = []
+    for line in text.splitlines():
+        line = line.strip()
+        if not line:
+            continue
+        try:
+            parts = next(csv.reader([line]))
+        except Exception:
+            parts = re.split(r"\s{2,}", line)
+        if len(parts) >= 3:
+            date, desc, amount = parts[0].strip(), parts[1].strip(), parts[2].strip()
+            rows.append({"Date": date, "Description": desc, "Amount": amount})
+    return rows


### PR DESCRIPTION
## Summary
- support PDF bank statements via basic OCR
- classify transactions with a lightweight classifier
- export trial balance and general ledger to CSV, PDF or Excel
- add helpers for PDF text extraction
- update dashboard and README

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687dcbc61df48320aeb77de714e332b3