### PR TITLE
Improve PDF parsing and upload validation

### DIFF
--- a/components/dashboard.py
+++ b/components/dashboard.py
@@ -7,7 +7,7 @@ from components.invoice_matcher_ui import run_invoice_matcher
 from utils.ledger import generate_ledger
 from utils.trial_balance import generate_trial_balance
 from utils.export import export_trial_balance, export_general_ledger
-from utils.pdf_utils import parse_bank_statement_pdf
+from utils.pdf_utils import parse_bank_statement_pdf, parse_bank_statement_csv
 
 def launch_dashboard(session):
     """Main dashboard screen shown after login."""
@@ -28,11 +28,12 @@ def launch_dashboard(session):
                 os.unlink(tmp_path)
             else:
                 content = bank_file.getvalue().decode("utf-8", errors="ignore")
-                reader = csv.DictReader(io.StringIO(content))
-                bank_rows = list(reader)
+                bank_rows = parse_bank_statement_csv(content)
             st.write("Transactions")
             st.table(bank_rows)
-        except Exception as exc:
+        except ValueError as exc:
+            st.error(str(exc))
+        except Exception as exc:  # pragma: no cover - unexpected I/O errors
             st.error(f"Failed to read bank statement: {exc}")
 
     run_invoice_matcher(bank_rows)

--- a/tests/test_parsers.py
+++ b/tests/test_parsers.py
@@ -1,0 +1,27 @@
+import os
+import tempfile
+import sys
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+from utils.pdf_utils import parse_bank_statement_csv, parse_bank_statement_pdf
+
+
+def test_parse_bank_statement_csv_missing_columns():
+    csv_text = "Date,Amount\n2023-01-01,100"
+    try:
+        parse_bank_statement_csv(csv_text)
+        assert False, "Expected ValueError"
+    except ValueError as exc:
+        assert "missing required columns" in str(exc)
+
+
+def test_parse_bank_statement_pdf_invalid(tmp_path):
+    # create a fake pdf file with garbage content
+    fake_pdf = tmp_path / "bad.pdf"
+    fake_pdf.write_text("not a real pdf")
+    try:
+        parse_bank_statement_pdf(str(fake_pdf))
+        assert False, "Expected ValueError"
+    except ValueError as exc:
+        assert "Could not" in str(exc) or "No text" in str(exc)

--- a/utils/pdf_utils.py
+++ b/utils/pdf_utils.py
@@ -3,6 +3,31 @@ import csv
 import re
 
 
+def parse_bank_statement_csv(csv_text):
+    """Parse CSV text and return a list of bank rows.
+
+    Raises
+    ------
+    ValueError
+        If the CSV is malformed or missing required columns.
+    """
+    try:
+        reader = csv.DictReader(io.StringIO(csv_text))
+    except csv.Error as exc:  # pragma: no cover - csv failures
+        raise ValueError(f"Invalid CSV format: {exc}") from exc
+
+    rows = list(reader)
+    if not rows:
+        raise ValueError("CSV file contained no rows")
+
+    required = {"Description", "Amount"}
+    missing = required - set(reader.fieldnames or [])
+    if missing:
+        raise ValueError(f"CSV missing required columns: {', '.join(sorted(missing))}")
+
+    return rows
+
+
 def extract_text(pdf_file_path, ocr=False):
     """Return text from a PDF file. If ``ocr`` is True and pytesseract is
     available, it will attempt OCR after converting pages to images.
@@ -38,7 +63,11 @@ def extract_text(pdf_file_path, ocr=False):
 
 def parse_bank_statement_pdf(pdf_file_path):
     """Parse a bank statement PDF and return a list of row dictionaries."""
+
     text = extract_text(pdf_file_path, ocr=True)
+    if not text.strip():
+        raise ValueError("No text could be extracted from the PDF")
+
     rows = []
     for line in text.splitlines():
         line = line.strip()
@@ -47,8 +76,17 @@ def parse_bank_statement_pdf(pdf_file_path):
         try:
             parts = next(csv.reader([line]))
         except Exception:
-            parts = re.split(r"\s{2,}", line)
+            parts = re.split(r"\s{2,}|\t+", line)
+        if len(parts) < 3:
+            match = re.match(r"(\d{2}/\d{2}/\d{4})\s+(.*?)\s+(-?\d[\d,\.]*?)$", line)
+            if match:
+                parts = [match.group(1), match.group(2), match.group(3)]
         if len(parts) >= 3:
             date, desc, amount = parts[0].strip(), parts[1].strip(), parts[2].strip()
+            amount = amount.replace("R", "").replace(",", "")
             rows.append({"Date": date, "Description": desc, "Amount": amount})
+
+    if not rows:
+        raise ValueError("Could not parse any transaction rows from PDF")
+
     return rows


### PR DESCRIPTION
## Summary
- add CSV parser helper and improve PDF parser
- validate uploaded bank statement files more carefully
- add tests for CSV and PDF parsing errors

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687e5948c6d08320911ba1bc74a2d6f3